### PR TITLE
fix: Use platform over deprecated linux_distribution

### DIFF
--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -15,7 +15,7 @@ fi
 default_LCG_release="LCG_98python3"
 default_LCG_platform="x86_64-centos7-gcc8-opt"
 # Check if on a CentOS 8 machine
-if [ "$(python3 -c 'import platform; print(platform.linux_distribution()[0])')" == 'CentOS Stream' ]; then
+if [ "$(python3 -c 'from platform import platform; print("centos-8" in platform())')" == "True" ]; then
     default_LCG_release="LCG_100"
     default_LCG_platform="x86_64-centos8-gcc10-opt"
 fi


### PR DESCRIPTION
`platform.dist()` and `platform.linux_distribution()` functions are [deprecated in Python 3.5](https://docs.python.org/3.5/library/platform.html#unix-platforms), so switch to using [`platform.platform()`](https://docs.python.org/3.9/library/platform.html#platform.platform).