### PR TITLE
fix: Change variable names for clarity and add notes

### DIFF
--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -62,8 +62,8 @@ EOT
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_name}"/bin/activate) + 2))"
     ed --silent "$(readlink -f "${_venv_name}"/bin/activate)" <<EOF
-${_SET_PYTHONPATH_INSERT_LINE}i
-${_SET_PYTHONPATH}
+${_RECOVER_OLD_PYTHONPATH_LINE}i
+${_RECOVER_OLD_PYTHONPATH}
 .
 wq
 EOF
@@ -73,8 +73,8 @@ EOF
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_name}"/bin/activate) + 2))"
     ed --silent "$(readlink -f "${_venv_name}"/bin/activate)" <<EOF
-${_RECOVER_OLD_PYTHONPATH_LINE}i
-${_RECOVER_OLD_PYTHONPATH}
+${_SET_PYTHONPATH_INSERT_LINE}i
+${_SET_PYTHONPATH}
 .
 wq
 EOF

--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -76,6 +76,4 @@ fi
 # Hide not-real errors from CVMFS by sending to /dev/null
 python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
 
-# Place venv's site-packages on PYTHONPATH to allow venv control of pip
-#export PYTHONPATH="$(find $(dirname $(command -v python))/../ -type d -name site-packages):${PYTHONPATH}"
 unset _venv_name


### PR DESCRIPTION
```
* Correct variable names as _SET_PYTHONPATH and _RECOVER_OLD_PYTHONPATH
were switched from what makes sense.
* Remove commented out line.
* Add comments to explain why the code blocks are written the way they
are and why they are being inserted in the specific places they are too.
```