### PR TITLE
feat: Update default LCG view to 101

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ $ ssh lxplus
 [feickert@lxplus732 ~]$ curl -sLO https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/atlas_setup.sh
 [feickert@lxplus732 ~]$ . atlas_setup.sh example
 
-lsetup 'views LCG_98python3 x86_64-centos7-gcc8-opt'
+lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'
 ************************************************************************
 Requested:  views ...
- Setting up views LCG_98python3:x86_64-centos7-gcc8-opt ...
+ Setting up views LCG_101:x86_64-centos7-gcc10-opt ...
 >>>>>>>>>>>>>>>>>>>>>>>>> Information for user <<<<<<<<<<<<<<<<<<<<<<<<<
 ************************************************************************
 # Creating new Python virtual environment 'example'
@@ -42,7 +42,7 @@ Home-page: UNKNOWN
 Author: UNKNOWN
 Author-email: UNKNOWN
 License: UNKNOWN
-Location: /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc8-opt/lib/python3.7/site-packages
+Location: /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc10-opt/lib/python3.9/site-packages
 Requires:
 Required-by:
 (example) [feickert@lxplus732 ~]$ python -m pip install --upgrade awkward  # This will show a false ERROR given CVFMS is in PYTHONPATH
@@ -62,19 +62,19 @@ Home-page: https://github.com/scikit-hep/awkward-1.0
 Author: Jim Pivarski
 Author-email: pivarski@princeton.edu
 License: BSD-3-Clause
-Location: /afs/cern.ch/user/f/feickert/example/lib/python3.7/site-packages
+Location: /afs/cern.ch/user/f/feickert/example/lib/python3.9/site-packages
 Requires: numpy, setuptools
-Required-by: uproot, uproot-methods
+Required-by:
 (example) [feickert@lxplus732 ~]$ deactivate  # Resets PYTHONPATH given added hooks
 [feickert@lxplus732 ~]$ python -m pip show awkward  # Get CVMFS's old version
 Name: awkward
-Version: 0.12.17
-Summary: Manipulate arrays of complex data structures as easily as Numpy.
-Home-page: https://github.com/scikit-hep/awkward-array
-Author: Jim Pivarski (IRIS-HEP)
+Version: 1.0.2
+Summary: Manipulate JSON-like data with NumPy-like idioms.
+Home-page: https://github.com/scikit-hep/awkward-1.0
+Author: Jim Pivarski
 Author-email: pivarski@princeton.edu
 License: BSD 3-clause
-Location: /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc8-opt/lib/python3.7/site-packages
-Requires: numpy
-Required-by: uproot, uproot-methods
+Location: /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc10-opt/lib/python3.9/site-packages
+Requires: setuptools, numpy
+Required-by:
 ```

--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -12,8 +12,8 @@ if [ "$?" == "1" ]; then
 fi
 
 # Setup default LCG view
-default_LCG_release="LCG_98python3"
-default_LCG_platform="x86_64-centos7-gcc8-opt"
+default_LCG_release="LCG_101"
+default_LCG_platform="x86_64-centos7-gcc10-opt"
 # Check if on a CentOS 8 machine
 if [ "$(python3 -c 'from platform import platform; print("centos-8" in platform())')" == "True" ]; then
     default_LCG_release="LCG_100"

--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -16,8 +16,8 @@ default_LCG_release="LCG_101"
 default_LCG_platform="x86_64-centos7-gcc10-opt"
 # Check if on a CentOS 8 machine
 if [ "$(python3 -c 'from platform import platform; print("centos-8" in platform())')" == "True" ]; then
-    default_LCG_release="LCG_100"
-    default_LCG_platform="x86_64-centos8-gcc10-opt"
+    default_LCG_release="LCG_101"
+    default_LCG_platform="x86_64-centos8-gcc11-opt"
 fi
 printf "\nlsetup 'views %s %s'\n" "${default_LCG_release}" "${default_LCG_platform}"
 lsetup "views ${default_LCG_release} ${default_LCG_platform}"


### PR DESCRIPTION
Resolves #7 

```
* Update default LCG view to LCG_101 x86_64-centos7-gcc10-opt.
* Update default CentOS 8 LCG view to LCG_101 x86_64-centos8-gcc11-opt.
* Update example in README to LCG_101 x86_64-centos7-gcc10-opt. 
```