### PR TITLE
chore: Update to using 'setupATLAS -3'

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This is done by injecting Bash snippets directly into the `bin/activate` script 
    ```
    vs.
    ```console
-   $ setupATLAS
+   $ setupATLAS -3
    $ lsetup "views LCG_101 x86_64-centos7-gcc10-opt"
    $ . venv/bin/activate
    ```
@@ -127,7 +127,7 @@ This is done by injecting Bash snippets directly into the `bin/activate` script 
    - Example: If you want to use [`rucio`][rucio-site] both inside and outside of the virtual environment you can set it up either before sourcing the `bin/activate` script
 
    ```console
-   $ setupATLAS
+   $ setupATLAS -3
    $ lsetup "views LCG_101 x86_64-centos7-gcc10-opt"
    $ lsetup rucio  # PYTHONPATH is altered by lsetup
    $ command -v rucio  # rucio is found
@@ -140,7 +140,7 @@ This is done by injecting Bash snippets directly into the `bin/activate` script 
    or after, as `cvmfs-venv-rebase` will update path variables and keep the virtual environment's directory trees at the heads.
 
    ```console
-   $ setupATLAS
+   $ setupATLAS -3
    $ lsetup "views LCG_101 x86_64-centos7-gcc10-opt"
    $ . venv/bin/activate
    (venv) $ lsetup rucio  # PYTHONPATH is altered by lsetup

--- a/atlas_setup.sh
+++ b/atlas_setup.sh
@@ -9,7 +9,7 @@ if [ -d "/cvmfs/atlas.cern.ch" ]; then
     if [ "$?" == "1" ]; then
         export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
         # Allows for working with wrappers as well
-        . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet || echo "~~~ERROR: setupATLAS failed!~~~"
+        . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh -3" --quiet || echo "~~~ERROR: setupATLAS failed!~~~"
     fi
 
     # Setup default LCG view


### PR DESCRIPTION
Currently (in March 2023) if setupATLAS is run a warning is printed of

centos7: setupATLAS is python3 environment by default (same as setupATLAS -3).
         If you need the previous python2 environment, do setupATLAS -2.
 	 We strongly encourage API users to migrate their scripts to python3.
          * * * This environment has been setup as python3. * * *

As

```
$ command -v setupATLAS
alias setupATLAS='source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh -3'
```

shows that it isn't required to append the '-3' option to setupATLAS it is worthwhile to add for now to help signal the Python 3 default.