### PR TITLE
ci: Add GitHub Actions based CI using analysisbase images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       # volumes:
       #  - ${{ github.workspace }}:/github-workspace
       # options: --workdir /workdir
+      options: --user root
     env:
       HOME: /home/atlas
     defaults:
@@ -47,10 +48,7 @@ jobs:
     - name: Place ~/.local/bin on PATH
       run: |
         mkdir -p ~/.local/bin
-        readlink -f ~
-        echo "PATH=~/.local/bin:${PATH}"
-        echo "${GITHUB_ENV}"
-        echo "PATH=~/.local/bin:${PATH}" >> $GITHUB_ENV
+        echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
     - name: Check runtime information
       run: |
         echo "CWD=$(pwd)"
-        ls -lhtra /
-        cp /github-workspace/cvmfs-venv.sh .
+        ls -lhtra /github-workspace
+        cp /github-workspace/cvmfs-venv/cvmfs-venv.sh .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"
         env
         echo "id:"
         id
-        echo 'export PATH=~/.local/bin:"${PATH}"' > ~/.bashrc
+        echo 'export PATH=/home/atlas/.local/bin:"${PATH}"' > /home/atlas/.bashrc
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
 
     - name: Install cvmfs-venv locally
       run: |
-        mkdir -p ~/.local/bin
-        mv cvmfs-venv.sh ~/.local/bin/
-        export PATH="~/.local/bin:${PATH}"
+        mkdir -p /home/atlas/.local/bin
+        mv cvmfs-venv.sh /home/atlas/.local/bin/cvmfs-venv
+        export PATH="/home/atlas/.local/bin:${PATH}"
         command -v cvmfs-venv
         echo "${PATH}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install cvmfs-venv locally
       run: |
         echo "PATH=${PATH}"
-        cp cvmfs-venv.sh ~/.local/bin/cvmfs-venv
+        mv cvmfs-venv.sh ~/.local/bin/cvmfs-venv
         echo "cvmfs-venv is: $(command -v cvmfs-venv)"
 
     - name: Setup default venv using /release_setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         . cvmfs-venv ${{ matrix.venv-name }}
         echo "# Python runtime: $(command -v python)"
         python --version --version
+        echo "PATH=${PATH}"
+        echo "PYTHONPATH=${PYTHONPATH}"
 
     - name: List installed Python packages
       run: |
@@ -103,6 +105,7 @@ jobs:
       run: |
         . /release_setup.sh
         . ${{ matrix.venv-name }}/bin/activate
+        echo "# deactivate"
         deactivate
         echo "# Python runtime: $(command -v python)"
         echo "PATH=${PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,14 @@ jobs:
         id
         echo 'export PATH=/home/atlas/.local/bin:"${PATH}"' > /home/atlas/.bashrc
 
-    - name: Install cvmfs-venv locally
+    - name: Place ~/.local/bin on PATH
       run: |
         mkdir -p /home/atlas/.local/bin
+        echo "PATH=/home/atlas/.local/bin:${PATH}" >> $GITHUB_ENV
+
+    - name: Install cvmfs-venv locally
+      run: |
         cp cvmfs-venv.sh /home/atlas/.local/bin/cvmfs-venv
-        export PATH="/home/atlas/.local/bin:${PATH}"
         command -v cvmfs-venv
         echo "${PATH}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+    defaults:
+      run:
+        shell: bash
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
@@ -20,7 +23,7 @@ jobs:
     - name: Install cvmfs-venv locally
       run: |
         mkdir -p /home/atlas/.local/bin
-        mv cvmfs-venv.sh /home/atlas/.local/bin/cvmfs-venv
+        cp cvmfs-venv.sh /home/atlas/.local/bin/cvmfs-venv
         export PATH="/home/atlas/.local/bin:${PATH}"
         command -v cvmfs-venv
         echo "${PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         mkdir -p ~/.local/bin
         # Need root permissions to set GITHUB_ENV
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
+        echo "env:"
+        env
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,17 +108,6 @@ jobs:
         echo "# python -m pip list"
         python -m pip list
 
-    - name: Reactivate environment
-      run: |
-        . /release_setup.sh
-        . ${{ matrix.venv-name }}/bin/activate
-        echo "PATH=${PATH}"
-        echo "PYTHONPATH=${PYTHONPATH}"
-        echo "# python -m pip list"
-        python -m pip list
-        echo "# python -m pip list --local"
-        python -m pip list --local
-
     - name: Uninstall NumPy to demonstrate can
       run: |
         . /release_setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     container: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
 
     steps:
-    - uses: actions/checkout@v3
+      # AnalysisBase Git version is too old to use modern checkout action
+    - uses: actions/checkout@v2
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        venv-name: ["venv", "example"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       # volumes:
@@ -58,14 +61,14 @@ jobs:
 
     - name: Setup venv using /release_setup.sh
       run: |
-        . cvmfs-venv
+        . cvmfs-venv ${{ matrix.venv-name }}
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
 
     - name: List installed Python packages
       run: |
         . /release_setup.sh
-        . venv/bin/activate
+        . ${{ matrix.venv-name }}/bin/activate
         echo "# python -m pip list"
         python -m pip list
         echo "# python -m pip list --local"
@@ -74,7 +77,7 @@ jobs:
     - name: Update NumPy and install Uproot
       run: |
         . /release_setup.sh
-        . venv/bin/activate
+        . ${{ matrix.venv-name }}/bin/activate
         python -m pip install --upgrade numpy uproot
         echo "# python -m pip list"
         python -m pip list
@@ -84,7 +87,7 @@ jobs:
     - name: Deactivate environment
       run: |
         . /release_setup.sh
-        . venv/bin/activate
+        . ${{ matrix.venv-name }}/bin/activate
         deactivate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
@@ -94,7 +97,7 @@ jobs:
     - name: Reactivate environment
       run: |
         . /release_setup.sh
-        . venv/bin/activate
+        . ${{ matrix.venv-name }}/bin/activate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
         echo "# python -m pip list"
@@ -105,7 +108,7 @@ jobs:
     - name: Uninstall NumPy to demonstrate can
       run: |
         . /release_setup.sh
-        . venv/bin/activate
+        . ${{ matrix.venv-name }}/bin/activate
         echo "# python -m pip uninstall -y numpy"
         python -m pip uninstall -y numpy
         echo "# python -m pip list"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,14 @@ jobs:
         python -m pip list
         echo "# python -m pip list --local"
         python -m pip list --local
+
+    - name: Uninstall NumPy to demonstrate can
+      run: |
+        . /release_setup.sh
+        . venv/bin/activate
+        echo "# python -m pip uninstall -y numpy"
+        python -m pip uninstall -y numpy
+        echo "# python -m pip list"
+        python -m pip list
+        echo "# python -m pip list --local"
+        python -m pip list --local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Setup venv using /release_setup.sh
       run: |
-        . cvmfs-venv
+        . cvmfs-venv.sh
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       volumes:
         - ${{ github.workspace }}:/github-workspace
-      options: --workdir /workdir
+      # options: --workdir /workdir
     defaults:
       run:
         shell: bash
@@ -30,7 +30,10 @@ jobs:
         echo "CWD=$(pwd)"
         ls -lhtra
         ls -lhtra /github-workspace
-        cp /github-workspace/* .
+        echo "ls -lhtra /__w"
+        ls -lhtra /__w
+        ls -lhtra /__w/cvmfs-venv
+        # cp /github-workspace/* .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Setup default venv using /release_setup.sh
       run: |
         . cvmfs-venv
-        command -v python
+        echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       run:
         shell: bash
         working-directory: /workdir
+        HOME: /home/atlas
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
       # AnalysisBase Git version is too old to use modern checkout action
     - uses: actions/checkout@v1
 
+    - name: Check runtime information
+      run: |
+        echo "CWD=$(pwd)"
+        echo "env:"
+        env
+        echo "id:"
+        id
+
     - name: Install cvmfs-venv locally
       run: |
         mkdir -p /home/atlas/.local/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       volumes:
         - ${{ github.workspace }}:/workdir
+      options: --workdir /workdir
     defaults:
       run:
         shell: bash
-        working-directory: /workdir
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
@@ -27,12 +27,13 @@ jobs:
     - name: Check runtime information
       run: |
         echo "CWD=$(pwd)"
+        echo "ls -lhtra:"
+        ls -lhtra
         echo "env:"
         env
         echo "id:"
         id
         echo 'export PATH=~/.local/bin:"${PATH}"' > ~/.bashrc
-        ls -lhtra
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         echo "CWD=$(pwd)"
         ls -lhtra
-        ls -lhtra /github-workspace
+        # ls -lhtra /github-workspace
         echo "ls -lhtra /__w"
         ls -lhtra /__w
         ls -lhtra /__w/cvmfs-venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
 
     - name: Install cvmfs-venv locally
       run: |
+        echo "PATH=${PATH}"
         cp cvmfs-venv.sh ~/.local/bin/cvmfs-venv
-        command -v cvmfs-venv
-        echo "${PATH}"
+        echo "cvmfs-venv is: $(command -v cvmfs-venv)"
 
     - name: Setup venv using /release_setup.sh
       run: |
-        . cvmfs-venv.sh
+        . cvmfs-venv
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
 
@@ -66,7 +66,9 @@ jobs:
       run: |
         . /release_setup.sh
         . venv/bin/activate
+        echo "# python -m pip list"
         python -m pip list
+        echo "# python -m pip list --local"
         python -m pip list --local
 
     - name: Update NumPy and install Uproot
@@ -74,7 +76,9 @@ jobs:
         . /release_setup.sh
         . venv/bin/activate
         python -m pip install --upgrade numpy uproot
+        echo "# python -m pip list"
         python -m pip list
+        echo "# python -m pip list --local"
         python -m pip list --local
 
     - name: Deactivate environment
@@ -84,6 +88,7 @@ jobs:
         deactivate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
+        echo "# python -m pip list"
         python -m pip list
 
     - name: Reactivate environment
@@ -92,5 +97,7 @@ jobs:
         . venv/bin/activate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
+        echo "# python -m pip list"
         python -m pip list
+        echo "# python -m pip list --local"
         python -m pip list --local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     defaults:
       run:
         shell: bash
+        # container options: --workdir not supported https://github.com/actions/runner/issues/878
+        # so set working-directory instead
         working-directory: /workdir
 
     steps:
@@ -33,7 +35,8 @@ jobs:
 
     - name: Setup directories
       run: |
-        cp -r /__w/cvmfs-venv/cvmfs-venv/cvmfs-venv.sh .
+        # Copy files from the GITHUB_WORKSPACE to the selected working directory
+        cp -r "${GITHUB_WORKSPACE}"/cvmfs-venv.sh .
         # Avoid warnings about cache ownership
         chown --recursive "$(id -u)" ~/
 
@@ -51,6 +54,7 @@ jobs:
     - name: Place ~/.local/bin on PATH
       run: |
         mkdir -p ~/.local/bin
+        # Need root permissions to set GITHUB_ENV
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Install cvmfs-venv locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
     - name: Place ~/.local/bin on PATH
       run: |
         mkdir -p ~/.local/bin
-        ls -lhtra ~/
+        readlink -f ~
         echo "PATH=~/.local/bin:${PATH}"
+        echo "${GITHUB_ENV}"
         echo "PATH=~/.local/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Install cvmfs-venv locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ jobs:
       # volumes:
       #  - ${{ github.workspace }}:/github-workspace
       # options: --workdir /workdir
+    env:
+      HOME: /home/atlas
     defaults:
       run:
         shell: bash
         working-directory: /workdir
-        HOME: /home/atlas
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        venv-name: ["venv", "example"]
+        venv-name: ["example"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       # volumes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,16 @@ jobs:
       # AnalysisBase Git version is too old to use modern checkout action
     - uses: actions/checkout@v1
 
+    - name: Setup directories
+      run: |
+        cp -r /__w/cvmfs-venv/cvmfs-venv/cvmfs-venv.sh .
+        # Avoid warnings about cache ownership
+        chown --recursive "$(id -u)" ~/
+
     - name: Check runtime information
       run: |
         echo "USER=${USER}"
         echo "CWD=$(pwd)"
-        ls -lhtra
-        # ls -lhtra /github-workspace
-        echo "ls -lhtra /__w"
-        ls -lhtra /__w
-        ls -lhtra /__w/cvmfs-venv/cvmfs-venv
-        # cp /github-workspace/* .
-        cp -r /__w/cvmfs-venv/cvmfs-venv/cvmfs-venv.sh .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"
@@ -53,8 +52,6 @@ jobs:
       run: |
         mkdir -p ~/.local/bin
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
-        # Avoid warnings about cache ownership
-        chown --recursive "$(id -u)" ~/
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         mkdir -p ~/.local/bin
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
         # Avoid warnings about cache ownership
-        chown --recursive "${USER}" ~/
+        chown --recursive "$(id -u)" ~/
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
         mkdir -p ~/.local/bin
         # Need root permissions to set GITHUB_ENV
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
-        echo "env:"
-        env
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       run: |
         mkdir -p ~/.local/bin
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
+        # Avoid warnings about cache ownership
+        chown --recursive "${USER}" ~/.cache
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
     - name: Check runtime information
       run: |
         echo "CWD=$(pwd)"
+        ls -lhtra
         ls -lhtra /github-workspace
-        cp /github-workspace/cvmfs-venv/cvmfs-venv.sh .
+        cp /github-workspace/* .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
-      volumes:
-        - ${{ github.workspace }}:/github-workspace
+      # volumes:
+      #  - ${{ github.workspace }}:/github-workspace
       # options: --workdir /workdir
     defaults:
       run:
@@ -34,6 +34,7 @@ jobs:
         ls -lhtra /__w
         ls -lhtra /__w/cvmfs-venv
         # cp /github-workspace/* .
+        cp -r /__w/cvmfs-venv/* .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
         venv-name: ["example"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
-      # volumes:
-      #  - ${{ github.workspace }}:/github-workspace
-      # options: --workdir /workdir
       options: --user root
     env:
       HOME: /home/atlas
@@ -35,6 +32,7 @@ jobs:
 
     - name: Setup directories
       run: |
+        # c.f. https://github.com/actions/runner/issues/2058 for why not using container volumes
         # Copy files from the GITHUB_WORKSPACE to the selected working directory
         cp -r "${GITHUB_WORKSPACE}"/cvmfs-venv.sh .
         # Avoid warnings about cache ownership
@@ -44,8 +42,6 @@ jobs:
       run: |
         echo "USER=${USER}"
         echo "CWD=$(pwd)"
-        echo "ls -lhtra:"
-        ls -lhtra
         echo "env:"
         env
         echo "id:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Setup venv "${{ matrix.venv-name }}" using /release_setup.sh
       run: |
         . cvmfs-venv ${{ matrix.venv-name }}
-        command -v python
+        echo "# Python runtime: $(command -v python)"
         python --version --version
 
     - name: List installed Python packages
@@ -90,6 +90,7 @@ jobs:
       run: |
         . /release_setup.sh
         . ${{ matrix.venv-name }}/bin/activate
+        echo "# python -m pip install --upgrade numpy uproot"
         python -m pip install --upgrade numpy uproot
         echo "# python -m pip list"
         python -m pip list
@@ -101,6 +102,7 @@ jobs:
         . /release_setup.sh
         . ${{ matrix.venv-name }}/bin/activate
         deactivate
+        echo "# Python runtime: $(command -v python)"
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
         echo "# python -m pip list"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         ls -lhtra /__w
         ls -lhtra /__w/cvmfs-venv/cvmfs-venv
         # cp /github-workspace/* .
-        cp -r /__w/cvmfs-venv/cvmfs-venv/* .
+        cp -r /__w/cvmfs-venv/cvmfs-venv/cvmfs-venv.sh .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"
@@ -59,17 +59,23 @@ jobs:
 
     - name: List installed Python packages
       run: |
+        . /release_setup.sh
+        . venv/bin/activate
         python -m pip list
         python -m pip list --local
 
     - name: Update NumPy and install Uproot
       run: |
+        . /release_setup.sh
+        . venv/bin/activate
         python -m pip install --upgrade numpy uproot
         python -m pip list
         python -m pip list --local
 
     - name: Deactivate environment
       run: |
+        . /release_setup.sh
+        . venv/bin/activate
         deactivate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       volumes:
-        - ${{ github.workspace }}:/workdir
+        - ${{ github.workspace }}:/github-workspace
       options: --workdir /workdir
     defaults:
       run:
@@ -27,6 +27,7 @@ jobs:
     - name: Check runtime information
       run: |
         echo "CWD=$(pwd)"
+        cp /github-workspace/cvmfs-venv.sh .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,23 @@ jobs:
         cp cvmfs-venv.sh ~/.local/bin/cvmfs-venv
         echo "cvmfs-venv is: $(command -v cvmfs-venv)"
 
-    - name: Setup venv using /release_setup.sh
+    - name: Setup default venv using /release_setup.sh
       run: |
-        . cvmfs-venv ${{ matrix.venv-name }}
+        . cvmfs-venv
+        command -v python
+        python --version --version
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
+
+    - name: Remove default venv
+      run: |
+        rm -rf venv
+
+    - name: Setup venv "${{ matrix.venv-name }}" using /release_setup.sh
+      run: |
+        . cvmfs-venv ${{ matrix.venv-name }}
+        command -v python
+        python --version --version
 
     - name: List installed Python packages
       run: |
@@ -115,3 +127,7 @@ jobs:
         python -m pip list
         echo "# python -m pip list --local"
         python -m pip list --local
+
+    - name: Remove venv "${{ matrix.venv-name }}"
+      run: |
+        rm -rf ${{ matrix.venv-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: /workdir
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
@@ -31,6 +32,7 @@ jobs:
         echo "id:"
         id
         echo 'export PATH=~/.local/bin:"${PATH}"' > ~/.bashrc
+        ls -lhtra
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Check runtime information
       run: |
+        echo "USER=${USER}"
         echo "CWD=$(pwd)"
         ls -lhtra
         # ls -lhtra /github-workspace
@@ -53,7 +54,7 @@ jobs:
         mkdir -p ~/.local/bin
         echo "PATH=$(readlink -f ~)/.local/bin:${PATH}" >> $GITHUB_ENV
         # Avoid warnings about cache ownership
-        chown --recursive "${USER}" ~/.cache
+        chown --recursive "${USER}" ~/
 
     - name: Install cvmfs-venv locally
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    container: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install cvmfs-venv locally
+      run: |
+        mkdir -p ~/.local/bin
+        mv cvmfs-venv.sh ~/.local/bin/
+        export PATH="~/.local/bin:${PATH}"
+        command -v cvmfs-venv
+        echo "${PATH}"
+
+    - name: Setup venv using /release_setup.sh
+      run: |
+        . cvmfs-venv
+        echo "PATH=${PATH}"
+        echo "PYTHONPATH=${PYTHONPATH}"
+
+    - name: List installed Python packages
+      run: |
+        python -m pip list
+        python -m pip list --local
+
+    - name: Update NumPy and install Uproot
+      run: |
+        python -m pip install --upgrade numpy uproot
+        python -m pip list
+        python -m pip list --local
+
+    - name: Deactivate environment
+      run: |
+        deactivate
+        echo "PATH=${PATH}"
+        echo "PYTHONPATH=${PYTHONPATH}"
+        python -m pip list
+
+    - name: Reactivate environment
+      run: |
+        . venv/bin/activate
+        echo "PATH=${PATH}"
+        echo "PYTHONPATH=${PYTHONPATH}"
+        python -m pip list
+        python -m pip list --local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: /workdir
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
@@ -27,6 +28,7 @@ jobs:
     - name: Check runtime information
       run: |
         echo "CWD=$(pwd)"
+        ls -lhtra /
         cp /github-workspace/cvmfs-venv.sh .
         echo "ls -lhtra:"
         ls -lhtra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
         # ls -lhtra /github-workspace
         echo "ls -lhtra /__w"
         ls -lhtra /__w
-        ls -lhtra /__w/cvmfs-venv
+        ls -lhtra /__w/cvmfs-venv/cvmfs-venv
         # cp /github-workspace/* .
-        cp -r /__w/cvmfs-venv/* .
+        cp -r /__w/cvmfs-venv/cvmfs-venv/* .
         echo "ls -lhtra:"
         ls -lhtra
         echo "env:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: /workdir
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,17 @@ jobs:
         env
         echo "id:"
         id
-        echo 'export PATH=/home/atlas/.local/bin:"${PATH}"' > /home/atlas/.bashrc
 
     - name: Place ~/.local/bin on PATH
       run: |
-        mkdir -p /home/atlas/.local/bin
-        echo "PATH=/home/atlas/.local/bin:${PATH}" >> $GITHUB_ENV
+        mkdir -p ~/.local/bin
+        ls -lhtra ~/
+        echo "PATH=~/.local/bin:${PATH}"
+        echo "PATH=~/.local/bin:${PATH}" >> $GITHUB_ENV
 
     - name: Install cvmfs-venv locally
       run: |
-        cp cvmfs-venv.sh /home/atlas/.local/bin/cvmfs-venv
+        cp cvmfs-venv.sh ~/.local/bin/cvmfs-venv
         command -v cvmfs-venv
         echo "${PATH}"
 
@@ -88,6 +89,7 @@ jobs:
 
     - name: Reactivate environment
       run: |
+        . /release_setup.sh
         . venv/bin/activate
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+    container:
+      image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+      volumes:
+        - ${{ github.workspace }}:/workdir
     defaults:
       run:
         shell: bash
-        working-directory: /workdir
 
     steps:
       # AnalysisBase Git version is too old to use modern checkout action
@@ -28,6 +30,7 @@ jobs:
         env
         echo "id:"
         id
+        echo 'export PATH=~/.local/bin:"${PATH}"' > ~/.bashrc
 
     - name: Install cvmfs-venv locally
       run: |


### PR DESCRIPTION
Add CI that demonstrates the cvmfs-venv workflow using ATLAS AnalysisBase images.

```
* Add Github Actions based CI workflow.
* Use gitlab-registry.cern.ch/atlas/athena/analysisbase images.
* Demonstrate workflow of cvmfs-venv using the AnalysisBase enviroment
  provided after sourcing /release_setup.sh.
```