### PR TITLE
feat: Add `--setup` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         echo "PATH=${PATH}"
         mv cvmfs-venv.sh ~/.local/bin/cvmfs-venv
         echo "cvmfs-venv is: $(command -v cvmfs-venv)"
+        . cvmfs-venv --help
 
     - name: Setup default venv using /release_setup.sh
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        venv-name: ["example"]
+        venv-name: ["example", "name-with-hyphens"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       options: --user root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         venv-name: ["example", "name-with-hyphens"]
-        setup-command: ["lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'"]
+        setup-command: [". /release_setup.sh", "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       options: --user root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         venv-name: ["example", "name-with-hyphens"]
-        setup-command: ["lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'"]
+        setup-command: ["\"lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'\""]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       options: --user root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         venv-name: ["example", "name-with-hyphens"]
-        setup-command: ["\"lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'\""]
+        setup-command: ["lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       options: --user root
@@ -74,7 +74,7 @@ jobs:
 
     - name: Setup venv "${{ matrix.venv-name }}" using /release_setup.sh
       run: |
-        . cvmfs-venv --setup ${{ matrix.setup-command }} ${{ matrix.venv-name }}
+        . cvmfs-venv --setup "${{ matrix.setup-command }}" ${{ matrix.venv-name }}
         echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "PATH=${PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         venv-name: ["example", "name-with-hyphens"]
+        setup-command: ["lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'"]
     container:
       image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
       options: --user root
@@ -73,7 +74,7 @@ jobs:
 
     - name: Setup venv "${{ matrix.venv-name }}" using /release_setup.sh
       run: |
-        . cvmfs-venv ${{ matrix.venv-name }}
+        . cvmfs-venv --setup ${{ matrix.setup-command }} ${{ matrix.venv-name }}
         echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "PATH=${PATH}"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ssh lxplus
 [feickert@lxplus732 ~]$ export PATH=~/.local/bin:"${PATH}"
 [feickert@lxplus732 ~]$ curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv
 [feickert@lxplus732 ~]$ chmod +x ~/.local/bin/cvmfs-venv
-[feickert@lxplus732 ~]$ . cvmfs-venv example
+[feickert@lxplus732 ~]$ . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
 
 lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'
 ************************************************************************
@@ -39,8 +39,8 @@ Requested:  views ...
  Setting up views LCG_101:x86_64-centos7-gcc10-opt ...
 >>>>>>>>>>>>>>>>>>>>>>>>> Information for user <<<<<<<<<<<<<<<<<<<<<<<<<
 ************************************************************************
-# Creating new Python virtual environment 'example'
-(example) [feickert@lxplus732 ~]$ python -m pip show lhapdf  # Still have full LCG view
+# Creating new Python virtual environment 'lcg-example'
+(lcg-example) [feickert@lxplus732 ~]$ python -m pip show lhapdf  # Still have full LCG view
 Name: LHAPDF
 Version: 6.3.0
 Summary: UNKNOWN
@@ -51,8 +51,8 @@ License: UNKNOWN
 Location: /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc10-opt/lib/python3.9/site-packages
 Requires:
 Required-by:
-(example) [feickert@lxplus732 ~]$ python -m pip install --upgrade awkward  # This will show a false ERROR given CVFMS is in PYTHONPATH
-(example) [feickert@lxplus732 ~]$ python
+(lcg-example) [feickert@lxplus732 ~]$ python -m pip install --upgrade awkward  # This will show a false ERROR given CVFMS is in PYTHONPATH
+(lcg-example) [feickert@lxplus732 ~]$ python
 Python 3.9.6 (default, Sep  6 2021, 15:35:00)
 [GCC 10.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
@@ -60,7 +60,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> import XRootD
 >>> import awkward
 >>> exit()
-(example) [feickert@lxplus732 ~]$ python -m pip show awkward  # Get version installed in venv
+(lcg-example) [feickert@lxplus732 ~]$ python -m pip show awkward  # Get version installed in venv
 Name: awkward
 Version: 2.1.0
 Summary: Manipulate JSON-like data with NumPy-like idioms.
@@ -68,10 +68,10 @@ Home-page:
 Author:
 Author-email: Jim Pivarski <pivarski@princeton.edu>
 License: BSD-3-Clause
-Location: /afs/cern.ch/user/f/feickert/example/lib/python3.9/site-packages
+Location: /afs/cern.ch/user/f/feickert/lcg-example/lib/python3.9/site-packages
 Requires: awkward-cpp, numpy, packaging, typing-extensions
 Required-by:
-(example) [feickert@lxplus732 ~]$ python -m pip list --local  # View of virtual environment controlled packages
+(lcg-example) [feickert@lxplus732 ~]$ python -m pip list --local  # View of virtual environment controlled packages
 Package           Version
 ----------------- -------
 awkward           2.1.0
@@ -80,7 +80,7 @@ pip               23.0.1
 setuptools        67.6.0
 typing_extensions 4.5.0
 wheel             0.40.0
-(example) [feickert@lxplus732 ~]$ deactivate  # Resets PYTHONPATH given added hooks
+(lcg-example) [feickert@lxplus732 ~]$ deactivate  # Resets PYTHONPATH given added hooks
 [feickert@lxplus732 ~]$ python -m pip show awkward  # Get CVMFS's old version
 Name: awkward
 Version: 1.0.2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,31 @@ $ chmod +x ~/.local/bin/cvmfs-venv
 Source the script to create a Python 3 virtual environment that can coexist with a CVMFS LCG view. The default name is `venv`.
 
 ```console
-$ . cvmfs-venv <name of your virtual environment>  # default name is 'venv'
+$ . cvmfs-venv --help
+Usage: cvmfs-venv [-s|--setup] <virtual environment name>
+
+Options:
+ -h --help      Print this help message
+ -s --setup     String of setup options to be parsed
+
+Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
+
+Example:
+
+    Setup LCG view 101 on CentOS7 and create a Python virtual environment named
+    'lgc-example' using the Python 3.9 runtime it provides.
+
+    . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
+
+    Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
+    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+
+    . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
+
+    Create a Python 3 virtual environment named 'venv' with whatever Python runtime
+    "$(command -v python3)" evaluates to.
+
+    . cvmfs-venv
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -29,25 +29,39 @@ Options:
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
-Example:
+Examples:
 
-    Setup LCG view 101 on CentOS7 and create a Python virtual environment named
-    'lgc-example' using the Python 3.9 runtime it provides.
+    * Setup LCG view 101 on CentOS7 and create a Python virtual environment
+    named 'lcg-example' using the Python 3.9 runtime it provides.
 
-    . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
+        . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
 
-    Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
+    * Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
     environment named 'alrb-example' using the Python 3.9 runtime it provides.
 
-    . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
 
-    Create a Python 3 virtual environment named 'venv' with whatever Python runtime
-    "$(command -v python3)" evaluates to.
+    * Create a Python 3 virtual environment named 'venv' with whatever Python
+    runtime "$(command -v python3)" evaluates to.
 
-    . cvmfs-venv
+        . cvmfs-venv
+
+    * Create a Python 3 virtual environment named 'lcg-example' with the Python
+    runtime provided by LCG view 101
+
+        setupATLAS -3
+        lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'
+        . cvmfs-venv lcg-example
+
+    * Create a Python 3 virtual environment named 'alrb-example' with the Python
+    runtime provided by ATLAS AnalysisBase release v22.2.110
+
+        setupATLAS -3
+        asetup AnalysisBase,22.2.110
+        . cvmfs-venv alrb-example
 ```
 
-### Example
+### Example: Virtual environment with LCG view
 
 ```console
 $ ssh lxplus

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -3,6 +3,110 @@
 # Ensure that pip can't install outside a virtual environment
 export PIP_REQUIRE_VIRTUALENV=true
 
+_help_options () {
+  cat <<EOF
+Usage: cvmfs-venv [-s|--setup] <virtual environment name>
+
+Options:
+ -h --help      Print this help message
+ -s --setup     String of setup options to be parsed
+
+Note: cvmfs-venv extends the Python venv module and so requires Python 3.6+.
+
+Example:
+
+    Setup LCG view 101 on CentOS7 and create a Python virtual environment named
+    'lgc-example' using the Python 3.9 runtime it provides.
+
+    . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
+
+    Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
+    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+
+    . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
+
+    Create a Python 3 virtual environment named 'venv' with whatever Python runtime
+    "\$(command -v python3)" evaluates to.
+
+    . cvmfs-venv
+EOF
+
+  return 0
+}
+
+# CLI API
+while [ $# -gt 0 ]; do
+    if [ $# -eq 1 ]; then
+        # this is the venv's name
+        break
+    fi
+    case "${1}" in
+        -h|--help)
+            _help_options
+            exit 0
+            ;;
+        -s|--setup)
+            _setup_command="${2}"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "ERROR: Invalid option '${1}'"
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -z "${_setup_command}" ]; then
+    if [ -f "/release_setup.sh" ]; then
+        # If in Linux container
+        if [[ "${_setup_command}" != *"/release_setup.sh"* ]]; then
+            echo "WARNING: /release_setup.sh exists and it is assumed you are in a Linux container."
+            echo "         '${_setup_command}' will be skipped in favor of using '. /release_setup.sh'."
+        fi
+        printf "\n. /release_setup.sh\n"
+        . /release_setup.sh
+    else
+        # Try to setup an environment using CVMFS
+        _do_setup_atlas=false
+        if [[ "${_setup_command}" == *"lsetup"* ]]; then
+            _do_setup_atlas=true
+        fi
+        if [[ "${_setup_command}" == *"asetup"* ]]; then
+            _do_setup_atlas=true
+        fi
+
+        if [ "${_do_setup_atlas}" = true ]; then
+            if [ -d "/cvmfs/atlas.cern.ch" ]; then
+                # Check to see if we need to run setupATLAS
+                command -v lsetup > /dev/null
+                if [ "$?" == "1" ]; then
+                    export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+                    # Allows for working with wrappers as well
+                    . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet || echo '~~~ERROR: setupATLAS failed!~~~'
+                fi
+
+                printf "\n${_setup_command}"
+                eval "${_setup_command}"
+            else
+                echo "ERROR: /cvmfs/atlas.cern.ch/ not found. Check that CernVM-FS is mounted correctly."
+                exit 1
+            fi
+        fi
+    fi
+# If in Linux container
+elif [ -f "/release_setup.sh" ]; then
+    echo "WARNING: /release_setup.sh exists and it is assumed you are in a Linux container."
+    echo "         Setting up environment with '. /release_setup.sh'."
+    . /release_setup.sh
+fi
+
+unset _setup_command
+unset _do_setup_atlas
+
 if [ -d "/cvmfs/atlas.cern.ch" ]; then
     # Check to see if we need to run setupATLAS
     command -v lsetup > /dev/null

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -99,7 +99,7 @@ if [ ! -z "${_setup_command}" ]; then
                     . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet || echo '~~~ERROR: setupATLAS failed!~~~'
                 fi
 
-                printf "\n${_setup_command}"
+                printf "\n${_setup_command}\n"
                 eval "${_setup_command}"
             else
                 echo "ERROR: /cvmfs/atlas.cern.ch/ not found. Check that CernVM-FS is mounted correctly."

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -107,31 +107,6 @@ fi
 unset _setup_command
 unset _do_setup_atlas
 
-if [ -d "/cvmfs/atlas.cern.ch" ]; then
-    # Check to see if we need to run setupATLAS
-    command -v lsetup > /dev/null
-    if [ "$?" == "1" ]; then
-        export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-        # Allows for working with wrappers as well
-        . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet || echo '~~~ERROR: setupATLAS failed!~~~'
-    fi
-
-    # Setup default LCG view
-    default_LCG_release="LCG_101"
-    default_LCG_platform="x86_64-centos7-gcc10-opt"
-    # Check if on a CentOS 8 machine
-    if [ "$(python3 -c 'from platform import platform; print("centos-8" in platform())')" == "True" ]; then
-        default_LCG_release="LCG_101"
-        default_LCG_platform="x86_64-centos8-gcc11-opt"
-    fi
-    printf "\nlsetup 'views %s %s'\n" "${default_LCG_release}" "${default_LCG_platform}"
-    lsetup "views ${default_LCG_release} ${default_LCG_platform}"
-
-elif [ -f "/release_setup.sh" ]; then
-    # If in Linux container
-    . /release_setup.sh
-fi
-
 _venv_name="${1:-venv}"
 if [ ! -d "${_venv_name}" ]; then
     printf "# Creating new Python virtual environment '%s'\n" "${_venv_name}"

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -11,7 +11,7 @@ Options:
  -h --help      Print this help message
  -s --setup     String of setup options to be parsed
 
-Note: cvmfs-venv extends the Python venv module and so requires Python 3.6+.
+Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
 Example:
 

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -52,8 +52,8 @@ while [ $# -gt 0 ]; do
             ;;
         *)
             if [ $# -eq 1 ]; then
-                # '-' also covers '--'
-                if [[ "${1}" != *"-"* ]]; then
+                #FIXME: Needs better guard
+                if [[ "${1}" != *"--"* ]]; then
                     # this is the venv's name
                     break
                 fi

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -51,8 +51,11 @@ while [ $# -gt 0 ]; do
             ;;
         *)
             if [ $# -eq 1 ]; then
-                # this is the venv's name
-                break
+                # '-' also covers '--'
+                if [[ "${1}" != *"-"* ]]; then
+                    # this is the venv's name
+                    break
+                fi
             fi
             echo "ERROR: Invalid option '${1}'"
             exit 1

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -36,10 +36,6 @@ EOF
 
 # CLI API
 while [ $# -gt 0 ]; do
-    if [ $# -eq 1 ]; then
-        # this is the venv's name
-        break
-    fi
     case "${1}" in
         -h|--help)
             _help_options
@@ -54,6 +50,10 @@ while [ $# -gt 0 ]; do
             break
             ;;
         *)
+            if [ $# -eq 1 ]; then
+                # this is the venv's name
+                break
+            fi
             echo "ERROR: Invalid option '${1}'"
             exit 1
             ;;

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -4,7 +4,7 @@
 export PIP_REQUIRE_VIRTUALENV=true
 
 _help_options () {
-  cat <<EOF
+    cat <<EOF
 Usage: cvmfs-venv [-s|--setup] <virtual environment name>
 
 Options:
@@ -13,22 +13,36 @@ Options:
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
-Example:
+Examples:
 
-    Setup LCG view 101 on CentOS7 and create a Python virtual environment named
-    'lgc-example' using the Python 3.9 runtime it provides.
+    * Setup LCG view 101 on CentOS7 and create a Python virtual environment
+    named 'lcg-example' using the Python 3.9 runtime it provides.
 
-    . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
+        . cvmfs-venv --setup "lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'" lcg-example
 
-    Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
+    * Setup ATLAS AnalysisBase release v22.2.110 and create a Python virtual
     environment named 'alrb-example' using the Python 3.9 runtime it provides.
 
-    . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.110' alrb-example
 
-    Create a Python 3 virtual environment named 'venv' with whatever Python runtime
-    "\$(command -v python3)" evaluates to.
+    * Create a Python 3 virtual environment named 'venv' with whatever Python
+    runtime "\$(command -v python3)" evaluates to.
 
-    . cvmfs-venv
+        . cvmfs-venv
+
+    * Create a Python 3 virtual environment named 'lcg-example' with the Python
+    runtime provided by LCG view 101
+
+        setupATLAS -3
+        lsetup 'views LCG_101 x86_64-centos7-gcc10-opt'
+        . cvmfs-venv lcg-example
+
+    * Create a Python 3 virtual environment named 'alrb-example' with the Python
+    runtime provided by ATLAS AnalysisBase release v22.2.110
+
+        setupATLAS -3
+        asetup AnalysisBase,22.2.110
+        . cvmfs-venv alrb-example
 EOF
 
   return 0

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -39,7 +39,8 @@ while [ $# -gt 0 ]; do
     case "${1}" in
         -h|--help)
             _help_options
-            exit 0
+            _return_break=0
+            break
             ;;
         -s|--setup)
             _setup_command="${2}"
@@ -58,10 +59,14 @@ while [ $# -gt 0 ]; do
                 fi
             fi
             echo "ERROR: Invalid option '${1}'"
-            exit 1
+            _return_break=1
+            break
             ;;
     esac
 done
+
+# FIXME: Find smarter way to filter guard virtual environment creation
+if [ -z "${_return_break}" ]; then
 
 if [ ! -z "${_setup_command}" ]; then
     if [ -f "/release_setup.sh" ]; then
@@ -299,3 +304,5 @@ fi
 python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
 
 unset _venv_name
+
+fi  # _return_break if statement end

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -35,6 +35,8 @@ EOF
 }
 
 # CLI API
+# N.B.: _return_break NEEDS to be unset before anything can be run
+unset _return_break
 while [ $# -gt 0 ]; do
     case "${1}" in
         -h|--help)
@@ -306,3 +308,5 @@ python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
 unset _venv_name
 
 fi  # _return_break if statement end
+
+unset _return_break


### PR DESCRIPTION
Allow users to specify the setup command they want by passing it as a string to `--setup` at the command line. Removes defaults.

```
* Add setup command.
* Remove default LCG view setup.
* Add --help option.
* Add `cvmfs-venv --help` information to README.
* Test multiple venv names and setup commands in CI.
```