### PR TITLE
docs: Add listing of full dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cvmfs-venv
 
-Example implementation of getting a Python virtual environment to work with CVMFS [LCG views][LCG_info]. This is done by adding additional hooks to the Python virtual environment's `bin/activate` script.
+Simple command line utility for getting a Python virtual environment to work with CVMFS [LCG views][LCG_info]. This is done by adding additional hooks to the Python virtual environment's `bin/activate` script.
 
 [LCG_info]: https://lcginfo.cern.ch/
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Requires: setuptools, numpy
 Required-by:
 ```
 
+## Dependencies
+
+`cvmfs-venv` has no dependencies beyond the ones it aims to extend: A Linux operating system that has CVMFS installed on it with a Python 3.3+ runtime with a functioning [`venv` module][venv docs].
+
+A full listing of all programs used outside of Bash shell builtins are:
+* `cat`
+* `ed`
+* `sed`
+* Python 3.3+ with `pip`
+
 ## Why is this needed?
 
 When an LCG view or an ATLAS computing environment that uses software from CVFMS is setup, it manipulates and alters the [`PYTHONPATH` environment variable][PYTHONPATH docs].


### PR DESCRIPTION
```
* Note that this is no longer an example implementation but can be used.
* Add "Dependencies" section to README.
   - Note that cvmfs-venv relies only on Bash shell builtins, cat, ed, sed,
     and Python 3.3+.
```