### PR TITLE
feat: Add '--no-update' option 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,13 @@ jobs:
     - name: Remove venv "${{ matrix.venv-name }}"
       run: |
         rm -rf ${{ matrix.venv-name }}
+
+    - name: Setup default venv with --no-update option
+      run: |
+        . cvmfs-venv --no-update
+        echo "# Python runtime: $(command -v python)"
+        python --version --version
+        echo "# python -m pip list"
+        python -m pip list
+        echo "# python -m pip list --local"
+        python -m pip list --local

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Usage: cvmfs-venv [-s|--setup] <virtual environment name>
 Options:
  -h --help      Print this help message
  -s --setup     String of setup options to be parsed
+ --no-update    After venv creation don't update pip, setuptools, and wheel
+                to the latest releases. Use of this option is not recommended,
+                but is faster.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -5,11 +5,14 @@ export PIP_REQUIRE_VIRTUALENV=true
 
 _help_options () {
     cat <<EOF
-Usage: cvmfs-venv [-s|--setup] <virtual environment name>
+Usage: cvmfs-venv [-s|--setup] [--no-update] <virtual environment name>
 
 Options:
  -h --help      Print this help message
  -s --setup     String of setup options to be parsed
+ --no-update    After venv creation don't update pip, setuptools, and wheel
+                to the latest releases. Use of this option is not recommended,
+                but is faster.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
@@ -61,6 +64,10 @@ while [ $# -gt 0 ]; do
         -s|--setup)
             _setup_command="${2}"
             shift 2
+            ;;
+        --no-update)
+            _no_update=true
+            shift
             ;;
         --)
             shift
@@ -318,10 +325,13 @@ fi
 
 # Get latest pip, setuptools, wheel
 # Hide not-real errors from CVMFS by sending to /dev/null
-python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
+if [ -z "${_no_update}" ]; then
+    python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
+fi
 
 unset _venv_name
 
 fi  # _return_break if statement end
 
 unset _return_break
+unset _no_update


### PR DESCRIPTION
Use of '--no-update' skips updating pip, setuptools, and wheel after the creation of the virtual environment. This isn't a great idea in general, but it does make environment creation faster.

```
* Use of '--no-update' skips updating pip, setuptools, and wheel after
  the creation of the virtual environment. This isn't a great idea in
  general, but it does make environment creation faster.
* Update README to note new option.
* Add check of '--no-update' to CI.
```