### PR TITLE
feat: Add '--system-site-packages' venv option by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
     - name: Setup default venv using /release_setup.sh
       run: |
         . cvmfs-venv
+        echo "# cat $(find . -type f -iname pyvenv.cfg)"
+        cat $(find . -type f -iname pyvenv.cfg)
         echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "PATH=${PATH}"
@@ -78,6 +80,8 @@ jobs:
     - name: Setup venv "${{ matrix.venv-name }}" using /release_setup.sh
       run: |
         . cvmfs-venv --setup "${{ matrix.setup-command }}" ${{ matrix.venv-name }}
+        echo "# cat $(find . -type f -iname pyvenv.cfg)"
+        cat $(find . -type f -iname pyvenv.cfg)
         echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "PATH=${PATH}"
@@ -133,10 +137,10 @@ jobs:
     - name: Setup default venv with --no-system-site-packages option
       run: |
         . cvmfs-venv --no-system-site-packages
-        echo "# Python runtime: $(command -v python)"
-        python --version --version
         echo "# cat $(find . -type f -iname pyvenv.cfg)"
         cat $(find . -type f -iname pyvenv.cfg)
+        echo "# Python runtime: $(command -v python)"
+        python --version --version
         echo "# python -m pip list"
         python -m pip list
         echo "# python -m pip list --local"
@@ -146,6 +150,8 @@ jobs:
     - name: Setup default venv with --no-update option
       run: |
         . cvmfs-venv --no-update
+        echo "# cat $(find . -type f -iname pyvenv.cfg)"
+        cat $(find . -type f -iname pyvenv.cfg)
         echo "# Python runtime: $(command -v python)"
         python --version --version
         echo "# python -m pip list"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         python --version --version
         echo "PATH=${PATH}"
         echo "PYTHONPATH=${PYTHONPATH}"
+        echo "# cat $(find . -type f -iname pyvenv.cfg)"
+        cat $(find . -type f -iname pyvenv.cfg)
 
     - name: Remove default venv
       run: |
@@ -128,6 +130,19 @@ jobs:
       run: |
         rm -rf ${{ matrix.venv-name }}
 
+    - name: Setup default venv with --no-system-site-packages option
+      run: |
+        . cvmfs-venv --no-system-site-packages
+        echo "# Python runtime: $(command -v python)"
+        python --version --version
+        echo "# cat $(find . -type f -iname pyvenv.cfg)"
+        cat $(find . -type f -iname pyvenv.cfg)
+        echo "# python -m pip list"
+        python -m pip list
+        echo "# python -m pip list --local"
+        python -m pip list --local
+        rm -rf venv
+
     - name: Setup default venv with --no-update option
       run: |
         . cvmfs-venv --no-update
@@ -137,3 +152,4 @@ jobs:
         python -m pip list
         echo "# python -m pip list --local"
         python -m pip list --local
+        rm -rf venv

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ The best that can be done is to control the directory tree at the **head** of `P
 While [`lcgenv`][lcgenv] allows for package specific environment building, it still lacks the control to specify arbitrary versions of Python packages and will load additional libraries beyond what is strictly required by the target package dependency requirements.
 That being said, if you are able to use an LCG view or `lcgenv` without any additional setup, you may not have need of specifying a Python virtual environment.
 
+While Python's [`venv` module][venv docs] does have the `--system-site-packages` option to
+
+> Give the virtual environment access to the system site-packages dir.
+
+this unfortunately isn't _quite_ enough.
+It does allow for isolation to work, but the manipulation of `PYTHONPATH` makes it so that while packages can be _installed_ properly in the local virtual environment and will show up with `python -m pip list` if there is another version of that package provided by the already setup environment that package version's location on `PYTHONPATH` will take precedence.
+Using `--system-site-packages` without `cvmfs-venv` is arguably even worse as it provides confusing differences in information between the user `pip list` view and the runtime environment.
+
 ## How things work
 
 `cvmfs-venv` provides a shim layer to manage activation and use of a Python virtual environment created with LCG view resources.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Options:
  --no-update    After venv creation don't update pip, setuptools, and wheel
                 to the latest releases. Use of this option is not recommended,
                 but is faster.
+--no-system-site-packages
+                The venv module '--system-site-packages' option is used by
+                default. While it is not recommended, this behavior can be
+                disabled through use of this flag.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Source the script to create a Python 3 virtual environment that can coexist with
 
 ```console
 $ . cvmfs-venv --help
-Usage: cvmfs-venv [-s|--setup] [--no-update] <virtual environment name>
+Usage: cvmfs-venv [-s|--setup] [--no-system-site-packages] [--no-update] <virtual environment name>
 
 Options:
  -h --help      Print this help message

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Usage: cvmfs-venv [-s|--setup] [--no-update] <virtual environment name>
 Options:
  -h --help      Print this help message
  -s --setup     String of setup options to be parsed
- --no-update    After venv creation don't update pip, setuptools, and wheel
-                to the latest releases. Use of this option is not recommended,
-                but is faster.
 --no-system-site-packages
                 The venv module '--system-site-packages' option is used by
                 default. While it is not recommended, this behavior can be
                 disabled through use of this flag.
+ --no-update    After venv creation don't update pip, setuptools, and wheel
+                to the latest releases. Use of this option is not recommended,
+                but is faster.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -5,7 +5,7 @@ export PIP_REQUIRE_VIRTUALENV=true
 
 _help_options () {
     cat <<EOF
-Usage: cvmfs-venv [-s|--setup] [--no-update] <virtual environment name>
+Usage: cvmfs-venv [-s|--setup] [--no-system-site-packages] [--no-update] <virtual environment name>
 
 Options:
  -h --help      Print this help message
@@ -13,6 +13,10 @@ Options:
  --no-update    After venv creation don't update pip, setuptools, and wheel
                 to the latest releases. Use of this option is not recommended,
                 but is faster.
+--no-system-site-packages
+                The venv module '--system-site-packages' option is used by
+                default. While it is not recommended, this behavior can be
+                disabled through use of this flag.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
@@ -64,6 +68,10 @@ while [ $# -gt 0 ]; do
         -s|--setup)
             _setup_command="${2}"
             shift 2
+            ;;
+        --no-system-site-packages)
+            _no_system_site_packages=true
+            shift
             ;;
         --no-update)
             _no_update=true
@@ -142,7 +150,11 @@ unset _do_setup_atlas
 _venv_name="${1:-venv}"
 if [ ! -d "${_venv_name}" ]; then
     printf "# Creating new Python virtual environment '%s'\n" "${_venv_name}"
-    python3 -m venv "${_venv_name}"
+    # Default to using --system-site-packages to add extra guards
+    if [ -z "${_no_system_site_packages}" ]; then
+        python3 -m venv "${_venv_name}"
+    fi
+    python3 -m venv --system-site-packages "${_venv_name}"
     _venv_full_path="$(readlink -f ${_venv_name})"
 
     # When setting up the Python virtual environment shell variables in the
@@ -334,4 +346,5 @@ unset _venv_name
 fi  # _return_break if statement end
 
 unset _return_break
+unset _no_system_site_packages
 unset _no_update

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -152,9 +152,10 @@ if [ ! -d "${_venv_name}" ]; then
     printf "# Creating new Python virtual environment '%s'\n" "${_venv_name}"
     # Default to using --system-site-packages to add extra guards
     if [ -z "${_no_system_site_packages}" ]; then
+        python3 -m venv --system-site-packages "${_venv_name}"
+    else
         python3 -m venv "${_venv_name}"
     fi
-    python3 -m venv --system-site-packages "${_venv_name}"
     _venv_full_path="$(readlink -f ${_venv_name})"
 
     # When setting up the Python virtual environment shell variables in the

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -10,13 +10,13 @@ Usage: cvmfs-venv [-s|--setup] [--no-system-site-packages] [--no-update] <virtua
 Options:
  -h --help      Print this help message
  -s --setup     String of setup options to be parsed
- --no-update    After venv creation don't update pip, setuptools, and wheel
-                to the latest releases. Use of this option is not recommended,
-                but is faster.
 --no-system-site-packages
                 The venv module '--system-site-packages' option is used by
                 default. While it is not recommended, this behavior can be
                 disabled through use of this flag.
+ --no-update    After venv creation don't update pip, setuptools, and wheel
+                to the latest releases. Use of this option is not recommended,
+                but is faster.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 


### PR DESCRIPTION
Resolves #32 

```
* Add '--system-site-packages' venv option by default.
* Add --no-system-site-packages cvmfs-venv option in the event
  a user wants to disable the default behavior.
* Add check to CI by cat-ing the contents of each virtual environment's
  yvenv.cfg.
* Add explanation to the docs on why use of --system-site-packages isn't enough.
```