### PR TITLE
docs: Put manual setup examples first

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,23 +40,8 @@ Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
 Examples:
 
-    * Setup LCG view 102 on CentOS7 and create a Python virtual environment
-    named 'lcg-example' using the Python 3.9 runtime it provides.
-
-        . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
-
-    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
-    environment named 'alrb-example' using the Python 3.9 runtime it provides.
-
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
-
-    * Create a Python 3 virtual environment named 'venv' with whatever Python
-    runtime "$(command -v python3)" evaluates to.
-
-        . cvmfs-venv
-
     * Create a Python 3 virtual environment named 'lcg-example' with the Python
-    runtime provided by LCG view 102.
+    runtime provided by LCG view 102 on CentOS7.
 
         setupATLAS -3
         lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
@@ -68,6 +53,21 @@ Examples:
         setupATLAS -3
         asetup AnalysisBase,22.2.113
         . cvmfs-venv alrb-example
+
+    * Create a Python 3 virtual environment named 'venv' with whatever Python
+    runtime "\$(command -v python3)" evaluates to.
+
+        . cvmfs-venv
+
+    * Setup LCG view 102 on CentOS7 and create a Python virtual environment
+    named 'lcg-example' using the Python 3.9 runtime it provides.
+
+        . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
+
+    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
+    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
 ```
 
 ### Example: Virtual environment with LCG view

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -22,23 +22,8 @@ Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
 Examples:
 
-    * Setup LCG view 102 on CentOS7 and create a Python virtual environment
-    named 'lcg-example' using the Python 3.9 runtime it provides.
-
-        . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
-
-    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
-    environment named 'alrb-example' using the Python 3.9 runtime it provides.
-
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
-
-    * Create a Python 3 virtual environment named 'venv' with whatever Python
-    runtime "\$(command -v python3)" evaluates to.
-
-        . cvmfs-venv
-
     * Create a Python 3 virtual environment named 'lcg-example' with the Python
-    runtime provided by LCG view 102.
+    runtime provided by LCG view 102 on CentOS7.
 
         setupATLAS -3
         lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
@@ -50,6 +35,21 @@ Examples:
         setupATLAS -3
         asetup AnalysisBase,22.2.113
         . cvmfs-venv alrb-example
+
+    * Create a Python 3 virtual environment named 'venv' with whatever Python
+    runtime "\$(command -v python3)" evaluates to.
+
+        . cvmfs-venv
+
+    * Setup LCG view 102 on CentOS7 and create a Python virtual environment
+    named 'lcg-example' using the Python 3.9 runtime it provides.
+
+        . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
+
+    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
+    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
 EOF
 
   return 0


### PR DESCRIPTION
People will want to use the easiest thing and having them change only a single command in a workflow is easier than using the `--setup` option.