### PR TITLE
feat: Add LCG view and ATLAS AnalysisBase examples

### DIFF
--- a/examples/analysis-base-example.sh
+++ b/examples/analysis-base-example.sh
@@ -16,15 +16,15 @@ cvmfs-venv atlas-ab-example
 echo "# . atlas-ab-example/bin/activate"
 . atlas-ab-example/bin/activate
 
+echo "# python -m pip list"
+python -m pip list
+echo "# python -m pip show cython"
+python -m pip show cython
+echo "# python -m pip install --upgrade cython"
+python -m pip install --upgrade cython
 echo "# python -m pip list --local"
 python -m pip list --local
-echo "# python -m pip show awkward"
-python -m pip show awkward
-echo "# python -m pip install --upgrade awkward"
-python -m pip install --upgrade awkward
-echo "# python -m pip list --local"
-python -m pip list --local
-echo "# python -m pip show awkward"
-python -m pip show awkward
-echo "# python -c 'import awkward; print(awkward.__version__)'"
-python -c 'import awkward; print(awkward.__version__)'
+echo "# python -m pip show cython"
+python -m pip show cython
+echo "# python -c 'import cython; print(cython.__version__)'"
+python -c 'import cython; print(cython.__version__)'

--- a/examples/analysis-base-example.sh
+++ b/examples/analysis-base-example.sh
@@ -28,3 +28,5 @@ echo "# python -m pip show cython"
 python -m pip show cython
 echo "# python -c 'import cython; print(cython.__version__)'"
 python -c 'import cython; print(cython.__version__)'
+echo "# python -c 'import ROOT; print(ROOT); import XRootD; print(XRootD)'"
+python -c 'import ROOT; print(ROOT); import XRootD; print(XRootD)'

--- a/examples/analysis-base-example.sh
+++ b/examples/analysis-base-example.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Install cvmfs-venv
 mkdir -p ~/.local/bin
 export PATH=~/.local/bin:"${PATH}"  # If ~/.local/bin not on PATH already
 curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv

--- a/examples/analysis-base-example.sh
+++ b/examples/analysis-base-example.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p ~/.local/bin
+export PATH=~/.local/bin:"${PATH}"  # If ~/.local/bin not on PATH already
+curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv
+chmod +x ~/.local/bin/cvmfs-venv
+
+# Guard against this being run in a subshell
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+. "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet  # setuptATLAS
+
+echo "# asetup AnalysisBase,22.2.113"
+asetup AnalysisBase,22.2.113
+echo "# cvmfs-venv atlas-ab-example"
+cvmfs-venv atlas-ab-example
+echo "# . atlas-ab-example/bin/activate"
+. atlas-ab-example/bin/activate
+
+echo "# python -m pip list --local"
+python -m pip list --local
+echo "# python -m pip show awkward"
+python -m pip show awkward
+echo "# python -m pip install --upgrade awkward"
+python -m pip install --upgrade awkward
+echo "# python -m pip list --local"
+python -m pip list --local
+echo "# python -m pip show awkward"
+python -m pip show awkward
+echo "# python -c 'import awkward; print(awkward.__version__)'"
+python -c 'import awkward; print(awkward.__version__)'

--- a/examples/lcg-example.sh
+++ b/examples/lcg-example.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p ~/.local/bin
+export PATH=~/.local/bin:"${PATH}"  # If ~/.local/bin not on PATH already
+curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv
+chmod +x ~/.local/bin/cvmfs-venv
+
+# Guard against this being run in a subshell
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+. "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet  # setuptATLAS
+
+echo "# lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'"
+lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
+echo "# cvmfs-venv lcg-example"
+cvmfs-venv lcg-example
+echo "# . lcg-example/bin/activate"
+. lcg-example/bin/activate
+
+echo "# python -m pip list --local"
+python -m pip list --local
+echo "# python -m pip show awkward"
+python -m pip show awkward
+echo "# python -m pip install --upgrade awkward"
+python -m pip install --upgrade awkward
+echo "# python -m pip list --local"
+python -m pip list --local
+echo "# python -m pip show awkward"
+python -m pip show awkward
+echo "# python -c 'import awkward; print(awkward.__version__)'"
+python -c 'import awkward; print(awkward.__version__)'

--- a/examples/lcg-example.sh
+++ b/examples/lcg-example.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Install cvmfs-venv
 mkdir -p ~/.local/bin
 export PATH=~/.local/bin:"${PATH}"  # If ~/.local/bin not on PATH already
 curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv


### PR DESCRIPTION
Add full examples of use with LCG view and ATLAS AnalysisBase examples. For greater similarity in workflow to a normal use of `python3 -m venv` use `cvmfs-venv` as a subshell command and then source the created virtual environment.

```
* Add example using LCG view 102.
* Add example using ATLAS AnalysisBase v22.2.113.
* In these examples use cvmfs-venv as command that does not need to
  be sourced to make it more similar to how one would use a normal Python
  virtual environment.
```