### PR TITLE
docs: Show virtual environment creation and activation separately 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This is done by injecting Bash snippets directly into the `bin/activate` script 
 * Once the virtual environment is setup and modified there is no additional dependency on the `cvmfs-venv` script that generated it.
    - While it saves time it is not needed. You can setup the environment again without it.
    ```console
-   $ . cvmfs-venv venv
+   $ . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" venv
    ```
    vs.
    ```console

--- a/README.md
+++ b/README.md
@@ -82,15 +82,16 @@ $ ssh lxplus
 [feickert@lxplus732 ~]$ export PATH=~/.local/bin:"${PATH}"
 [feickert@lxplus732 ~]$ curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/main/cvmfs-venv.sh -o ~/.local/bin/cvmfs-venv
 [feickert@lxplus732 ~]$ chmod +x ~/.local/bin/cvmfs-venv
-[feickert@lxplus732 ~]$ . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
-
-lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
+[feickert@lxplus732 ~]$ setupATLAS -3 --quiet
+[feickert@lxplus732 ~]$ lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
 ************************************************************************
 Requested:  views ...
  Setting up views LCG_102:x86_64-centos7-gcc11-opt ...
 >>>>>>>>>>>>>>>>>>>>>>>>> Information for user <<<<<<<<<<<<<<<<<<<<<<<<<
 ************************************************************************
+[feickert@lxplus732 ~]$ cvmfs-venv lcg-example
 # Creating new Python virtual environment 'lcg-example'
+[feickert@lxplus732 ~]$ . lcg-example/bin/activate
 (lcg-example) [feickert@lxplus732 ~]$ python -m pip show lhapdf  # Still have full LCG view
 Name: LHAPDF
 Version: 6.5.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ chmod +x ~/.local/bin/cvmfs-venv
 Source the script to create a Python 3 virtual environment that can coexist with a CVMFS LCG view. The default name is `venv`.
 
 ```console
-$ . cvmfs-venv --help
+$ cvmfs-venv --help
 Usage: cvmfs-venv [-s|--setup] [--no-system-site-packages] [--no-update] <virtual environment name>
 
 Options:
@@ -45,19 +45,22 @@ Examples:
 
         setupATLAS -3
         lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
-        . cvmfs-venv lcg-example
+        cvmfs-venv lcg-example
+        . lcg-example/bin/activate
 
-    * Create a Python 3 virtual environment named 'alrb-example' with the Python
-    runtime provided by ATLAS AnalysisBase release v22.2.113.
+    * Create a Python 3 virtual environment named 'atlas-ab-example' with the
+    Python runtime provided by ATLAS AnalysisBase release v22.2.113.
 
         setupATLAS -3
         asetup AnalysisBase,22.2.113
-        . cvmfs-venv alrb-example
+        cvmfs-venv atlas-ab-example
+        . atlas-ab-example/bin/activate
 
     * Create a Python 3 virtual environment named 'venv' with whatever Python
     runtime "\$(command -v python3)" evaluates to.
 
-        . cvmfs-venv
+        cvmfs-venv
+        . venv/bin/activate
 
     * Setup LCG view 102 on CentOS7 and create a Python virtual environment
     named 'lcg-example' using the Python 3.9 runtime it provides.
@@ -65,9 +68,10 @@ Examples:
         . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
 
     * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
-    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+    environment named 'atlas-ab-example' using the Python 3.9 runtime it
+    provides.
 
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' atlas-ab-example
 ```
 
 ### Example: Virtual environment with LCG view

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -27,19 +27,22 @@ Examples:
 
         setupATLAS -3
         lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'
-        . cvmfs-venv lcg-example
+        cvmfs-venv lcg-example
+        . lcg-example/bin/activate
 
-    * Create a Python 3 virtual environment named 'alrb-example' with the Python
-    runtime provided by ATLAS AnalysisBase release v22.2.113.
+    * Create a Python 3 virtual environment named 'atlas-ab-example' with the
+    Python runtime provided by ATLAS AnalysisBase release v22.2.113.
 
         setupATLAS -3
         asetup AnalysisBase,22.2.113
-        . cvmfs-venv alrb-example
+        cvmfs-venv atlas-ab-example
+        . atlas-ab-example/bin/activate
 
     * Create a Python 3 virtual environment named 'venv' with whatever Python
     runtime "\$(command -v python3)" evaluates to.
 
-        . cvmfs-venv
+        cvmfs-venv
+        . venv/bin/activate
 
     * Setup LCG view 102 on CentOS7 and create a Python virtual environment
     named 'lcg-example' using the Python 3.9 runtime it provides.
@@ -47,9 +50,10 @@ Examples:
         . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
 
     * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
-    environment named 'alrb-example' using the Python 3.9 runtime it provides.
+    environment named 'atlas-ab-example' using the Python 3.9 runtime it
+    provides.
 
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' alrb-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' atlas-ab-example
 EOF
 
   return 0


### PR DESCRIPTION
```
* Also rename 'alrb-example' to 'atlas-ab-example'.
* Update usage example to show virtual environment creation
  and then activation.
* Show correct full resetup of environment with --setup.
```