### PR TITLE
feat: Use --no-cache-dir for better use in containers

### DIFF
--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -343,7 +343,7 @@ fi
 # Get latest pip, setuptools, wheel
 # Hide not-real errors from CVMFS by sending to /dev/null
 if [ -z "${_no_update}" ]; then
-    python -m pip --quiet install --upgrade pip setuptools wheel &> /dev/null
+    python -m pip --quiet --no-cache-dir install --upgrade pip setuptools wheel &> /dev/null
 fi
 
 unset _venv_name


### PR DESCRIPTION
* As cache directories aren't useful in Linux container images disable the cache directory for pip when doing the automatic upgrade of pip, setuptools, and wheel after virtual environment creation.