### PR TITLE
ci: Update AnalysisBase to release 24.2.2 for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         venv-name: ["example", "name-with-hyphens"]
         setup-command: [". /release_setup.sh", "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'"]
     container:
-      image: gitlab-registry.cern.ch/atlas/athena/analysisbase:22.2.113
+      image: gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.2
       options: --user root
     env:
       HOME: /home/atlas

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Examples:
         . lcg-example/bin/activate
 
     * Create a Python 3 virtual environment named 'atlas-ab-example' with the
-    Python runtime provided by ATLAS AnalysisBase release v22.2.113.
+    Python runtime provided by ATLAS AnalysisBase release v24.2.2.
 
         setupATLAS -3
-        asetup AnalysisBase,22.2.113
+        asetup AnalysisBase,24.2.2
         cvmfs-venv atlas-ab-example
         . atlas-ab-example/bin/activate
 
@@ -67,11 +67,11 @@ Examples:
 
         . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
 
-    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
+    * Setup ATLAS AnalysisBase release v24.2.2 and create a Python virtual
     environment named 'atlas-ab-example' using the Python 3.9 runtime it
     provides.
 
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' atlas-ab-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,24.2.2' atlas-ab-example
 ```
 
 ### Example: Virtual environment with LCG view

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -31,10 +31,10 @@ Examples:
         . lcg-example/bin/activate
 
     * Create a Python 3 virtual environment named 'atlas-ab-example' with the
-    Python runtime provided by ATLAS AnalysisBase release v22.2.113.
+    Python runtime provided by ATLAS AnalysisBase release v24.2.2.
 
         setupATLAS -3
-        asetup AnalysisBase,22.2.113
+        asetup AnalysisBase,24.2.2
         cvmfs-venv atlas-ab-example
         . atlas-ab-example/bin/activate
 
@@ -49,11 +49,11 @@ Examples:
 
         . cvmfs-venv --setup "lsetup 'views LCG_102 x86_64-centos7-gcc11-opt'" lcg-example
 
-    * Setup ATLAS AnalysisBase release v22.2.113 and create a Python virtual
+    * Setup ATLAS AnalysisBase release v24.2.2 and create a Python virtual
     environment named 'atlas-ab-example' using the Python 3.9 runtime it
     provides.
 
-        . cvmfs-venv --setup 'asetup AnalysisBase,22.2.113' atlas-ab-example
+        . cvmfs-venv --setup 'asetup AnalysisBase,24.2.2' atlas-ab-example
 EOF
 
   return 0

--- a/examples/analysis-base-example.sh
+++ b/examples/analysis-base-example.sh
@@ -10,8 +10,8 @@ chmod +x ~/.local/bin/cvmfs-venv
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" -3 --quiet  # setuptATLAS
 
-echo "# asetup AnalysisBase,22.2.113"
-asetup AnalysisBase,22.2.113
+echo "# asetup AnalysisBase,24.2.2"
+asetup AnalysisBase,24.2.2
 echo "# cvmfs-venv atlas-ab-example"
 cvmfs-venv atlas-ab-example
 echo "# . atlas-ab-example/bin/activate"


### PR DESCRIPTION
* As Release 22 won't be used for analysis use Release 24 for testing instead.
* Update image used for testing to analysisbase:24.2.2.
* Update AnalysisBase release to 4.2.2 in README examples.