### PR TITLE
fix: Add support for 'vi' if 'ed' isn't installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Required-by: cabinetry, coffea, servicex, uproot_browser
 
 A full listing of all programs used outside of Bash shell builtins are:
 * `cat`
+* `ed`
 * `find`
 * `readlink`
 * `sed`

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Required-by: cabinetry, coffea, servicex, uproot_browser
 
 A full listing of all programs used outside of Bash shell builtins are:
 * `cat`
-* `ed`
 * `find`
 * `readlink`
 * `sed`

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Required-by: cabinetry, coffea, servicex, uproot_browser
 
 A full listing of all programs used outside of Bash shell builtins are:
 * `cat`
+* `ed` or `vi`
 * `find`
 * `readlink`
 * `sed`

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -289,7 +289,7 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    cat <<EOF > "${_venv_full_path}/bin/activate"
+    ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RECOVER_OLD_PYTHONPATH_LINE}i
 ${_RECOVER_OLD_PYTHONPATH}
 .
@@ -300,7 +300,7 @@ EOF
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    cat <<EOF > "${_venv_full_path}/bin/activate"
+    ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_SET_PYTHONPATH_INSERT_LINE}i
 ${_SET_PYTHONPATH}
 .
@@ -310,7 +310,7 @@ EOF
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
-    cat <<EOF > "${_venv_full_path}/bin/activate"
+    ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RUN_REBASE_LINE}i
 ${_RUN_REBASE}
 .
@@ -320,7 +320,7 @@ EOF
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
-    cat <<EOF > "${_venv_full_path}/bin/activate"
+    ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_DESCTRUCTIVE_UNSET_LINE}i
 ${_DESCTRUCTIVE_UNSET}
 .
@@ -330,7 +330,7 @@ EOF
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
-    cat <<EOF > "${_venv_full_path}/bin/activate"
+    ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_CVMFS_VENV_REBASE_LINE}i
 ${_CVMFS_VENV_REBASE}
 .

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -289,53 +289,28 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
-${_RECOVER_OLD_PYTHONPATH_LINE}i
-${_RECOVER_OLD_PYTHONPATH}
-.
-wq
-EOF
+    sed --in-place "${_RECOVER_OLD_PYTHONPATH_LINE}i ${_RECOVER_OLD_PYTHONPATH}" "${_venv_full_path}/bin/activate"
 
     # Find the line number of the last line in deactivate's PYTHONHOME reset
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
-${_SET_PYTHONPATH_INSERT_LINE}i
-${_SET_PYTHONPATH}
-.
-wq
-EOF
+    sed --in-place "${_SET_PYTHONPATH_INSERT_LINE}i ${_SET_PYTHONPATH}" "${_venv_full_path}/bin/activate"
 
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
-${_RUN_REBASE_LINE}i
-${_RUN_REBASE}
-.
-wq
-EOF
+    sed --in-place "${_RUN_REBASE_LINE}i ${_RUN_REBASE}" "${_venv_full_path}/bin/activate"
 
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
-${_DESCTRUCTIVE_UNSET_LINE}i
-${_DESCTRUCTIVE_UNSET}
-.
-wq
-EOF
+    sed --in-place "${_DESCTRUCTIVE_UNSET_LINE}i ${_DESCTRUCTIVE_UNSET}" "${_venv_full_path}/bin/activate"
 
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
-${_CVMFS_VENV_REBASE_LINE}i
-${_CVMFS_VENV_REBASE}
-.
-wq
-EOF
+    sed --in-place "${_CVMFS_VENV_REBASE_LINE}i ${_CVMFS_VENV_REBASE}" "${_venv_full_path}/bin/activate"
 
 unset _venv_full_path
 

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -301,9 +301,6 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    echo "_RECOVER_OLD_PYTHONPATH_LINE: ${_RECOVER_OLD_PYTHONPATH_LINE}"
-    echo "_RECOVER_OLD_PYTHONPATH: ${_RECOVER_OLD_PYTHONPATH}"
-
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RECOVER_OLD_PYTHONPATH_LINE}i
@@ -320,7 +317,6 @@ ${_RECOVER_OLD_PYTHONPATH}
 .
 wq
 EOF
-
         vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
     fi
 
@@ -328,9 +324,6 @@ EOF
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    echo "_SET_PYTHONPATH_INSERT_LINE: ${_SET_PYTHONPATH_INSERT_LINE}"
-    echo "_SET_PYTHONPATH: ${_SET_PYTHONPATH}"
-
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_SET_PYTHONPATH_INSERT_LINE}i
@@ -347,16 +340,12 @@ ${_SET_PYTHONPATH}
 .
 wq
 EOF
-
         vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
     fi
 
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
-    echo "_RUN_REBASE_LINE: ${_RUN_REBASE_LINE}"
-    echo "_RUN_REBASE: ${_RUN_REBASE}"
-
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RUN_REBASE_LINE}i
@@ -373,16 +362,12 @@ ${_RUN_REBASE}
 .
 wq
 EOF
-
         vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
     fi
 
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
-    echo "_DESCTRUCTIVE_UNSET_LINE: ${_DESCTRUCTIVE_UNSET_LINE}"
-    echo "_DESCTRUCTIVE_UNSET: ${_DESCTRUCTIVE_UNSET}"
-
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_DESCTRUCTIVE_UNSET_LINE}i
@@ -399,16 +384,12 @@ ${_DESCTRUCTIVE_UNSET}
 .
 wq
 EOF
-
         vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
     fi
 
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
-    echo "_CVMFS_VENV_REBASE_LINE: ${_CVMFS_VENV_REBASE_LINE}"
-    echo "_CVMFS_VENV_REBASE: ${_CVMFS_VENV_REBASE}"
-
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_CVMFS_VENV_REBASE_LINE}i
@@ -425,7 +406,6 @@ ${_CVMFS_VENV_REBASE}
 .
 wq
 EOF
-
         vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
     fi
 

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -301,6 +301,7 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
+    # FIXME: Make a cleaner implimentation
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RECOVER_OLD_PYTHONPATH_LINE}i
@@ -324,6 +325,7 @@ EOF
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
+    # FIXME: Make a cleaner implimentation
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_SET_PYTHONPATH_INSERT_LINE}i
@@ -346,6 +348,7 @@ EOF
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
+    # FIXME: Make a cleaner implimentation
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_RUN_REBASE_LINE}i
@@ -368,6 +371,7 @@ EOF
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
+    # FIXME: Make a cleaner implimentation
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_DESCTRUCTIVE_UNSET_LINE}i
@@ -390,6 +394,7 @@ EOF
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
+    # FIXME: Make a cleaner implimentation
     if [ "${_text_editor}" == "ed" ]; then
         ed --silent "${_venv_full_path}/bin/activate" <<EOF
 ${_CVMFS_VENV_REBASE_LINE}i

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -289,7 +289,7 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
+    cat <<EOF > "${_venv_full_path}/bin/activate"
 ${_RECOVER_OLD_PYTHONPATH_LINE}i
 ${_RECOVER_OLD_PYTHONPATH}
 .
@@ -300,7 +300,7 @@ EOF
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
+    cat <<EOF > "${_venv_full_path}/bin/activate"
 ${_SET_PYTHONPATH_INSERT_LINE}i
 ${_SET_PYTHONPATH}
 .
@@ -310,7 +310,7 @@ EOF
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
+    cat <<EOF > "${_venv_full_path}/bin/activate"
 ${_RUN_REBASE_LINE}i
 ${_RUN_REBASE}
 .
@@ -320,7 +320,7 @@ EOF
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
+    cat <<EOF > "${_venv_full_path}/bin/activate"
 ${_DESCTRUCTIVE_UNSET_LINE}i
 ${_DESCTRUCTIVE_UNSET}
 .
@@ -330,7 +330,7 @@ EOF
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
-    ed --silent "${_venv_full_path}/bin/activate" <<EOF
+    cat <<EOF > "${_venv_full_path}/bin/activate"
 ${_CVMFS_VENV_REBASE_LINE}i
 ${_CVMFS_VENV_REBASE}
 .

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -310,7 +310,7 @@ ${_RECOVER_OLD_PYTHONPATH}
 wq
 EOF
     else
-        # only supporting vim so don't need to check
+        # only supporting vi so don't need to check
         _vi_script=$(mktemp)
         cat <<EOF > "${_vi_script}"
 ${_RECOVER_OLD_PYTHONPATH_LINE}i
@@ -334,7 +334,7 @@ ${_SET_PYTHONPATH}
 wq
 EOF
     else
-        # only supporting vim so don't need to check
+        # only supporting vi so don't need to check
         _vi_script=$(mktemp)
         cat <<EOF > "${_vi_script}"
 ${_SET_PYTHONPATH_INSERT_LINE}i
@@ -357,7 +357,7 @@ ${_RUN_REBASE}
 wq
 EOF
     else
-        # only supporting vim so don't need to check
+        # only supporting vi so don't need to check
         _vi_script=$(mktemp)
         cat <<EOF > "${_vi_script}"
 ${_RUN_REBASE_LINE}i
@@ -380,7 +380,7 @@ ${_DESCTRUCTIVE_UNSET}
 wq
 EOF
     else
-        # only supporting vim so don't need to check
+        # only supporting vi so don't need to check
         _vi_script=$(mktemp)
         cat <<EOF > "${_vi_script}"
 ${_DESCTRUCTIVE_UNSET_LINE}i
@@ -403,7 +403,7 @@ ${_CVMFS_VENV_REBASE}
 wq
 EOF
     else
-        # only supporting vim so don't need to check
+        # only supporting vi so don't need to check
         _vi_script=$(mktemp)
         cat <<EOF > "${_vi_script}"
 ${_CVMFS_VENV_REBASE_LINE}i

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -157,6 +157,18 @@ fi
 unset _setup_command
 unset _do_setup_atlas
 
+# determine text editor to use for complicated edits to the activate script
+if [ -x "$(command -v ed)" ]; then
+    # default to using 'ed'
+    _text_editor="ed"
+elif [ -x "$(command -v vi)" ]; then
+    # fall back to 'vi'
+    _text_editor="vi"
+else
+    echo "ERROR: Neither 'ed' nor 'vi' is installed. Please install one of them."
+    exit 1
+fi
+
 _venv_name="${1:-venv}"
 if [ ! -d "${_venv_name}" ]; then
     printf "# Creating new Python virtual environment '%s'\n" "${_venv_name}"
@@ -289,28 +301,133 @@ EOT
     # block and inject the PYTHONPATH if statement block directly after it
     # (2 lines later).
     _RECOVER_OLD_PYTHONPATH_LINE="$(($(sed -n '\|unset _OLD_VIRTUAL_PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    sed --in-place "${_RECOVER_OLD_PYTHONPATH_LINE}i ${_RECOVER_OLD_PYTHONPATH}" "${_venv_full_path}/bin/activate"
+    echo "_RECOVER_OLD_PYTHONPATH_LINE: ${_RECOVER_OLD_PYTHONPATH_LINE}"
+    echo "_RECOVER_OLD_PYTHONPATH: ${_RECOVER_OLD_PYTHONPATH}"
+
+    if [ "${_text_editor}" == "ed" ]; then
+        ed --silent "${_venv_full_path}/bin/activate" <<EOF
+${_RECOVER_OLD_PYTHONPATH_LINE}i
+${_RECOVER_OLD_PYTHONPATH}
+.
+wq
+EOF
+    else
+        # only supporting vim so don't need to check
+        _vi_script=$(mktemp)
+        cat <<EOF > "${_vi_script}"
+${_RECOVER_OLD_PYTHONPATH_LINE}i
+${_RECOVER_OLD_PYTHONPATH}
+.
+wq
+EOF
+
+        vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
+    fi
 
     # Find the line number of the last line in deactivate's PYTHONHOME reset
     # if statement block and inject the PYTHONPATH reset if statement block directly
     # after it (2 lines later).
     _SET_PYTHONPATH_INSERT_LINE="$(($(sed -n '\|    unset PYTHONHOME|=' "${_venv_full_path}"/bin/activate) + 2))"
-    sed --in-place "${_SET_PYTHONPATH_INSERT_LINE}i ${_SET_PYTHONPATH}" "${_venv_full_path}/bin/activate"
+    echo "_SET_PYTHONPATH_INSERT_LINE: ${_SET_PYTHONPATH_INSERT_LINE}"
+    echo "_SET_PYTHONPATH: ${_SET_PYTHONPATH}"
+
+    if [ "${_text_editor}" == "ed" ]; then
+        ed --silent "${_venv_full_path}/bin/activate" <<EOF
+${_SET_PYTHONPATH_INSERT_LINE}i
+${_SET_PYTHONPATH}
+.
+wq
+EOF
+    else
+        # only supporting vim so don't need to check
+        _vi_script=$(mktemp)
+        cat <<EOF > "${_vi_script}"
+${_SET_PYTHONPATH_INSERT_LINE}i
+${_SET_PYTHONPATH}
+.
+wq
+EOF
+
+        vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
+    fi
 
     # Find the line number of the deactivate function and inject the cvmfs-venv-rebase directly after it
     # (1 line later).
     _RUN_REBASE_LINE="$(($(sed -n '\|deactivate ()|=' "${_venv_full_path}"/bin/activate) + 1))"
-    sed --in-place "${_RUN_REBASE_LINE}i ${_RUN_REBASE}" "${_venv_full_path}/bin/activate"
+    echo "_RUN_REBASE_LINE: ${_RUN_REBASE_LINE}"
+    echo "_RUN_REBASE: ${_RUN_REBASE}"
+
+    if [ "${_text_editor}" == "ed" ]; then
+        ed --silent "${_venv_full_path}/bin/activate" <<EOF
+${_RUN_REBASE_LINE}i
+${_RUN_REBASE}
+.
+wq
+EOF
+    else
+        # only supporting vim so don't need to check
+        _vi_script=$(mktemp)
+        cat <<EOF > "${_vi_script}"
+${_RUN_REBASE_LINE}i
+${_RUN_REBASE}
+.
+wq
+EOF
+
+        vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
+    fi
 
     # Find the line number of the unset -f deactivate line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase reset directly after it (1 line later).
     _DESCTRUCTIVE_UNSET_LINE="$(($(sed -n '\|unset -f deactivate|=' "${_venv_full_path}"/bin/activate) + 1))"
-    sed --in-place "${_DESCTRUCTIVE_UNSET_LINE}i ${_DESCTRUCTIVE_UNSET}" "${_venv_full_path}/bin/activate"
+    echo "_DESCTRUCTIVE_UNSET_LINE: ${_DESCTRUCTIVE_UNSET_LINE}"
+    echo "_DESCTRUCTIVE_UNSET: ${_DESCTRUCTIVE_UNSET}"
+
+    if [ "${_text_editor}" == "ed" ]; then
+        ed --silent "${_venv_full_path}/bin/activate" <<EOF
+${_DESCTRUCTIVE_UNSET_LINE}i
+${_DESCTRUCTIVE_UNSET}
+.
+wq
+EOF
+    else
+        # only supporting vim so don't need to check
+        _vi_script=$(mktemp)
+        cat <<EOF > "${_vi_script}"
+${_DESCTRUCTIVE_UNSET_LINE}i
+${_DESCTRUCTIVE_UNSET}
+.
+wq
+EOF
+
+        vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
+    fi
 
     # Find the line number of the unset -f cvmfs-venv-rebase line in deactivate's destructive unset
     # and inject the cvmfs-venv-rebase function directly after it (4 lines later).
     _CVMFS_VENV_REBASE_LINE="$(($(sed -n '\|unset -f cvmfs-venv-rebase|=' "${_venv_full_path}"/bin/activate) + 4))"
-    sed --in-place "${_CVMFS_VENV_REBASE_LINE}i ${_CVMFS_VENV_REBASE}" "${_venv_full_path}/bin/activate"
+    echo "_CVMFS_VENV_REBASE_LINE: ${_CVMFS_VENV_REBASE_LINE}"
+    echo "_CVMFS_VENV_REBASE: ${_CVMFS_VENV_REBASE}"
+
+    if [ "${_text_editor}" == "ed" ]; then
+        ed --silent "${_venv_full_path}/bin/activate" <<EOF
+${_CVMFS_VENV_REBASE_LINE}i
+${_CVMFS_VENV_REBASE}
+.
+wq
+EOF
+    else
+        # only supporting vim so don't need to check
+        _vi_script=$(mktemp)
+        cat <<EOF > "${_vi_script}"
+${_CVMFS_VENV_REBASE_LINE}i
+${_CVMFS_VENV_REBASE}
+.
+wq
+EOF
+
+        vi -es "${_venv_full_path}/bin/activate" < "${_vi_script}"
+    fi
 
 unset _venv_full_path
 
@@ -355,3 +472,4 @@ unset _return_break
 unset _no_system_site_packages
 unset _no_update
 unset _no_uv
+unset _text_editor


### PR DESCRIPTION
Resolves #52 

As a full text editor is useful for writing the complicated multi-line patches into the `activate` script, fall back to using `vi` if `ed` is not installed.

```
* As a full text editor is useful for writing the complicated multi-line
  patches into the 'activate' script, fall back to using 'vi' if 'ed' is
  not installed.
* Note that 'ed' or 'vi' works in the README.
```