### PR TITLE
chore: Remove upgrade of wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Options:
                 The venv module '--system-site-packages' option is used by
                 default. While it is not recommended, this behavior can be
                 disabled through use of this flag.
- --no-update    After venv creation don't update pip, setuptools, and wheel
-                to the latest releases. Use of this option is not recommended,
+ --no-update    After venv creation don't update pip and setuptools to the
+                latest releases. Use of this option is not recommended,
                 but is faster.
  --no-uv        After venv creation don't install uv and use it to update pip,
-                setuptools, and wheel. By default, uv is installed.
+                and setuptools. By default, uv is installed.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
@@ -100,7 +100,6 @@ Package    Version
 pip        24.0
 setuptools 69.5.1
 uv         0.1.42
-wheel      0.43.0
 (lcg-example) [feickert@lxplus924 ~]$ python -m pip show hepdata-lib  # Still have full LCG view
 Name: hepdata-lib
 Version: 0.12.0
@@ -145,7 +144,6 @@ pip                24.0
 setuptools         69.5.1
 typing_extensions  4.11.0
 uv                 0.1.42
-wheel              0.43.0
 zipp               3.18.1
 (lcg-example) [feickert@lxplus924 ~]$ uv pip list  # uv will show the same view
 Package            Version
@@ -160,7 +158,6 @@ pip                24.0
 setuptools         69.5.1
 typing-extensions  4.11.0
 uv                 0.1.42
-wheel              0.43.0
 zipp               3.18.1
 (lcg-example) [feickert@lxplus924 ~]$ deactivate  # Resets PYTHONPATH given added hooks
 [feickert@lxplus924 ~]$ python -m pip show awkward  # Get CVMFS's old version

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -14,11 +14,11 @@ Options:
                 The venv module '--system-site-packages' option is used by
                 default. While it is not recommended, this behavior can be
                 disabled through use of this flag.
- --no-update    After venv creation don't update pip, setuptools, and wheel
-                to the latest releases. Use of this option is not recommended,
+ --no-update    After venv creation don't update pip and setuptools to the
+                latest releases. Use of this option is not recommended,
                 but is faster.
  --no-uv        After venv creation don't install uv and use it to update pip,
-                setuptools, and wheel. By default, uv is installed.
+                and setuptools. By default, uv is installed.
 
 Note: cvmfs-venv extends the Python venv module and so requires Python 3.3+.
 
@@ -438,14 +438,14 @@ if [ -z "${_no_uv}" ]; then
     python -m pip --quiet --no-cache-dir install --upgrade uv &> /dev/null
 fi
 
-# Get latest pip, setuptools, wheel
+# Get latest pip and setuptools
 if [ -z "${_no_update}" ]; then
     # Use uv by default
     if [ -z "${_no_uv}" ]; then
-        uv pip --quiet install --upgrade pip setuptools wheel
+        uv pip --quiet install --upgrade pip setuptools
     else
         # Hide not-real errors from CVMFS by sending to /dev/null
-        python -m pip --quiet --no-cache-dir install --upgrade pip setuptools wheel &> /dev/null
+        python -m pip --quiet --no-cache-dir install --upgrade pip setuptools &> /dev/null
     fi
 fi
 


### PR DESCRIPTION
* Remove install and upgrade of wheel.
   - For dependencies that don't provide a wheel, and don't have build-system metadata in pyproject.toml, modern setuptools has integrated wheel and so installation is unnecessary.
   - c.f. https://github.com/pypa/setuptools/pull/3859