### PR TITLE
feat: Globally install uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Package    Version
 ---------- -------
 pip        24.0
 setuptools 69.5.1
-uv         0.1.42
 (lcg-example) [feickert@lxplus924 ~]$ python -m pip show hepdata-lib  # Still have full LCG view
 Name: hepdata-lib
 Version: 0.12.0
@@ -143,7 +142,6 @@ packaging          24.0
 pip                24.0
 setuptools         69.5.1
 typing_extensions  4.11.0
-uv                 0.1.42
 zipp               3.18.1
 (lcg-example) [feickert@lxplus924 ~]$ uv pip list  # uv will show the same view
 Package            Version
@@ -157,7 +155,6 @@ packaging          24.0
 pip                24.0
 setuptools         69.5.1
 typing-extensions  4.11.0
-uv                 0.1.42
 zipp               3.18.1
 (lcg-example) [feickert@lxplus924 ~]$ deactivate  # Resets PYTHONPATH given added hooks
 [feickert@lxplus924 ~]$ python -m pip show awkward  # Get CVMFS's old version

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Required-by: cabinetry, coffea, servicex, uproot_browser
 
 A full listing of all programs used outside of Bash shell builtins are:
 * `cat`
+* `curl`
 * `ed` or `vi`
 * `find`
 * `readlink`

--- a/cvmfs-venv.sh
+++ b/cvmfs-venv.sh
@@ -435,7 +435,29 @@ fi
 
 # Install uv by default
 if [ -z "${_no_uv}" ]; then
-    python -m pip --quiet --no-cache-dir install --upgrade uv &> /dev/null
+    # Ensure that uv is installed
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "# Installing uv"
+        # Check if pixi exists
+        if command -v pixi >/dev/null 2>&1; then
+            # Use pixi global
+            echo "# Installing uv with pixi global"
+            echo "# You can update uv with 'pixi global update uv'"
+            pixi global install uv
+        else
+            # Install from https://astral.sh/
+            echo "# Installing from https://astral.sh/"
+            echo "# You can update uv with 'uv self update'"
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+        fi
+
+        # Ensure ~/.local/bin is on the PATH for uv
+        if [[ ":$PATH:" != *":${HOME}/.local/bin:"* ]]; then
+            export PATH="${HOME}/.local/bin:${PATH}"
+        fi
+        # Enable uv shell autocompletion
+        eval "$(uv generate-shell-completion bash)"
+    fi
 fi
 
 # Get latest pip and setuptools


### PR DESCRIPTION
Resolves #58 

* Globally install uv instead of installing it in the Python virtual environment. This simplifies workflows and gets people using uv more.
* Note that curl is an added required dependency.